### PR TITLE
Add builder for Ubuntu 18.04 Bionic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ xenial: ## Build AMI for Ubuntu 16.04 ("Xenial") LTS
 	@cd xenial && packer validate template.json
 	@cd xenial && packer build template.json
 
+.PHONY: bionic
+bionic: ## Build AMI for Ubuntu 18.04 ("Bionic") LTS
+	@cd bionic && packer validate template.json
+	@cd bionic && packer build template.json
+
 .PHONY: help
 help: ## Display this information. Default target.
 	@echo "Valid targets:"

--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@
 
 This repository contains [Packer][packerio] templates for building Amazon Machine Images for Ubuntu with a ZFS root filesystem. Currently the following distributions are supported:
 
+- Ubuntu 18.04 ("Bionic") LTS with AWS-Optimized Kernel
 - Ubuntu 16.04 ("Xenial") LTS with AWS-Optimized Kernel
 
-The template is easily modified for Debian and later Ubuntu distributions, however.
+The template is easily modified for Debian and other recent Ubuntu distributions, however.
 
-A detailed description of how the template works is available on the [operator-error.com][oe] blog, in the post [Building ZFS Root Ubuntu AMIs with Packer][oepost].
+A detailed description of how the template works is available on the [operator-error.com][oe] blog, in the post [Building ZFS Root Ubuntu AMIs with Packer][oepost]. Note that the package set needed for ZFS from Ubuntu 18.04 onwards is different.
 
 ## Running a build
 
 **Note that you'll need Packer v0.12.3 or above in order to build these templates.**
 
-Use the `xenial` or targets of the Makefile in root of the repository to build an AMI in `us-west-2`, and copy it to all regions.
+Use the `bionic` or `xenial` targets of the Makefile in root of the repository to build an AMI in `us-west-2`, and copy it to all regions.
 
 The following environment variables must be set in order for the build to succeed:
 

--- a/bionic/scripts/chroot-bootstrap.sh
+++ b/bionic/scripts/chroot-bootstrap.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+# Update APT with new sources
+apt-get update
+
+# Do not configure grub during package install
+echo 'grub-pc grub-pc/install_devices_empty select true' | debconf-set-selections
+echo 'grub-pc grub-pc/install_devices select' | debconf-set-selections
+
+# Install various packages needed for a booting system
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+	linux-aws \
+	grub-pc \
+	zfsutils-linux \
+	zfs-initramfs \
+	gdisk
+
+# Set the locale to en_US.UTF-8
+locale-gen --purge "en_US.UTF-8"
+echo -e 'LANG="en_US.UTF-8"\nLANGUAGE="en_US:en"\n' > /etc/default/locale
+
+# Install OpenSSH
+apt-get install -y --no-install-recommends openssh-server
+
+# Install GRUB
+# shellcheck disable=SC2016
+sed -ri 's/GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX="boot=zfs \$bootfs"/' /etc/default/grub
+grub-probe /
+grub-install /dev/xvdf
+
+# Configure and update GRUB
+mkdir -p /etc/default/grub.d
+{
+	echo 'GRUB_RECORDFAIL_TIMEOUT=0'
+	echo 'GRUB_TIMEOUT=0'
+	echo 'GRUB_CMDLINE_LINUX_DEFAULT="console=tty1 console=ttyS0 ip=dhcp tsc=reliable net.ifnames=0"'
+	echo 'GRUB_TERMINAL=console'
+} > /etc/default/grub.d/50-aws-settings.cfg
+update-grub
+
+# Set options for the default interface
+cat << EOF > /etc/netplan/eth0.yaml
+network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp4: true
+EOF
+
+# Install standard packages
+DEBIAN_FRONTEND=noninteractive apt-get install -y ubuntu-standard cloud-init

--- a/bionic/scripts/sources-us-west-2.list
+++ b/bionic/scripts/sources-us-west-2.list
@@ -1,0 +1,49 @@
+# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
+# newer versions of the distribution.
+deb http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ bionic main restricted
+deb-src http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ bionic main restricted
+
+## Major bug fix updates produced after the final release of the
+## distribution.
+deb http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ bionic-updates main restricted
+deb-src http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ bionic-updates main restricted
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
+## team. Also, please note that software in universe WILL NOT receive any
+## review or updates from the Ubuntu security team.
+deb http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ bionic universe
+deb-src http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ bionic universe
+deb http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ bionic-updates universe
+deb-src http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ bionic-updates universe
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu 
+## team, and may not be under a free licence. Please satisfy yourself as to 
+## your rights to use the software. Also, please note that software in 
+## multiverse WILL NOT receive any review or updates from the Ubuntu
+## security team.
+deb http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ bionic multiverse
+deb-src http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ bionic multiverse
+deb http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ bionic-updates multiverse
+deb-src http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ bionic-updates multiverse
+
+## N.B. software from this repository may not have been tested as
+## extensively as that contained in the main release, although it includes
+## newer versions of some applications which may provide useful features.
+## Also, please note that software in backports WILL NOT receive any review
+## or updates from the Ubuntu security team.
+deb http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ bionic-backports main restricted universe multiverse
+deb-src http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ bionic-backports main restricted universe multiverse
+
+deb http://security.ubuntu.com/ubuntu bionic-security main restricted
+deb-src http://security.ubuntu.com/ubuntu bionic-security main restricted
+deb http://security.ubuntu.com/ubuntu bionic-security universe
+deb-src http://security.ubuntu.com/ubuntu bionic-security universe
+deb http://security.ubuntu.com/ubuntu bionic-security multiverse
+deb-src http://security.ubuntu.com/ubuntu bionic-security multiverse
+
+## Uncomment the following two lines to add software from Canonical's
+## 'partner' repository.
+## This software is not part of Ubuntu, but is offered by Canonical and the
+## respective vendors as a service to Ubuntu users.
+# deb http://archive.canonical.com/ubuntu bionic partner
+# deb-src http://archive.canonical.com/ubuntu bionic partner

--- a/bionic/scripts/surrogate-bootstrap.sh
+++ b/bionic/scripts/surrogate-bootstrap.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+# Update apt and install required packages
+DEBIAN_FRONTEND=noninteractive sudo apt-get update
+DEBIAN_FRONTEND=noninteractive sudo apt-get install -y \
+	zfsutils-linux \
+	debootstrap \
+	gdisk
+
+# Partition the new root EBS volume
+sudo sgdisk -Zg -n1:0:4095 -t1:EF02 -c1:GRUB -n2:0:0 -t2:BF01 -c2:ZFS /dev/xvdf
+
+# Create zpool and filesystems on the new EBS volume
+sudo zpool create \
+	-o altroot=/mnt \
+	-o ashift=12 \
+	-o cachefile=/etc/zfs/zpool.cache \
+	-O canmount=off \
+	-O compression=lz4 \
+	-O atime=off \
+	-O normalization=formD \
+	-m none \
+	rpool \
+	/dev/xvdf2
+
+# Root file system
+sudo zfs create \
+	-o canmount=off \
+	-o mountpoint=none \
+	rpool/ROOT
+
+sudo zfs create \
+	-o canmount=noauto \
+	-o mountpoint=/ \
+	rpool/ROOT/ubuntu
+
+sudo zfs mount rpool/ROOT/ubuntu
+
+# /home
+sudo zfs create \
+	-o setuid=off \
+	-o mountpoint=/home \
+	rpool/home
+
+sudo zfs create \
+	-o mountpoint=/root \
+	rpool/home/root
+
+# /var
+sudo zfs create \
+	-o setuid=off \
+	-o overlay=on \
+	-o mountpoint=/var \
+	rpool/var
+
+sudo zfs create \
+	-o com.sun:auto-snapshot=false \
+	-o mountpoint=/var/cache \
+	rpool/var/cache
+
+sudo zfs create \
+	-o com.sun:auto-snapshot=false \
+	-o mountpoint=/var/tmp \
+	rpool/var/tmp
+
+sudo zfs create \
+	-o mountpoint=/var/spool \
+	rpool/var/spool
+
+sudo zfs create \
+	-o exec=on \
+	-o mountpoint=/var/lib \
+	rpool/var/lib
+
+sudo zfs create \
+	-o mountpoint=/var/log \
+	rpool/var/log
+
+# Display ZFS output for debugging purposes
+sudo zpool status
+sudo zfs list
+
+# Bootstrap Ubuntu into /mnt
+sudo debootstrap --arch amd64 bionic /mnt
+sudo cp /tmp/sources.list /mnt/etc/apt/sources.list
+
+# Copy the zpool cache
+sudo mkdir -p /mnt/etc/zfs
+sudo cp -p /etc/zfs/zpool.cache /mnt/etc/zfs/zpool.cache
+
+# Create mount points and mount the filesystem
+sudo mkdir -p /mnt/{dev,proc,sys}
+sudo mount --rbind /dev /mnt/dev
+sudo mount --rbind /proc /mnt/proc
+sudo mount --rbind /sys /mnt/sys
+
+# Copy the bootstrap script into place and execute inside chroot
+sudo cp /tmp/chroot-bootstrap.sh /mnt/tmp/chroot-bootstrap.sh
+sudo chroot /mnt /tmp/chroot-bootstrap.sh
+sudo rm -f /mnt/tmp/chroot-bootstrap.sh
+
+# Remove temporary sources list - CloudInit regenerates it
+sudo rm -f /mnt/etc/apt/sources.list
+
+# This could perhaps be replaced (more reliably) with an `lsof | grep -v /mnt` loop,
+# however in approximately 20 runs, the bind mounts have not failed to unmount.
+sleep 10 
+
+# Unmount bind mounts
+sudo umount -l /mnt/dev
+sudo umount -l /mnt/proc
+sudo umount -l /mnt/sys
+
+# Export the zpool
+sudo zpool export rpool

--- a/bionic/template.json
+++ b/bionic/template.json
@@ -1,0 +1,85 @@
+{
+	"variables": {
+		"aws_access_key_id": "{{ env `AWS_ACCESS_KEY_ID` }}",
+		"aws_secret_access_key": "{{ env `AWS_SECRET_ACCESS_KEY` }}",
+		"region": "us-west-2",
+		"buildtime": "{{isotime \"2006-01-02-1504\"}}"
+	},
+	"builders": [{
+		"type": "amazon-ebssurrogate",
+		"access_key": "{{ user `aws_access_key_id` }}",
+		"secret_key": "{{ user `aws_secret_access_key` }}",
+		"region": "{{user `region`}}",
+
+		"spot_price": "auto",
+		"spot_price_auto_product": "Linux/UNIX (Amazon VPC)",
+
+		"ssh_pty": true,
+		"instance_type": "m4.large",
+		"associate_public_ip_address": true,
+		"ssh_username": "ubuntu",
+		"ssh_timeout": "5m",
+
+		"source_ami_filter": {
+			"filters": {
+				"virtualization-type": "hvm",
+				"name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*",
+				"root-device-type": "ebs"
+			},
+			"owners": ["099720109477"],
+			"most_recent": true
+		},
+
+		"launch_block_device_mappings": [
+			{
+				"device_name": "/dev/xvdf",
+				"delete_on_termination": true,
+				"volume_size": 8,
+				"volume_type": "gp2"
+			}
+		],
+
+		"run_tags": {
+			"Name": "Packer Builder - ZFS Root Ubuntu",
+			"Project": "operator-error.com"
+		},
+		"run_volume_tags": {
+			"Name": "Packer Builder - ZFS Root Ubuntu",
+			"Project": "operator-error.com"
+		},
+
+		"ami_name": "ubuntu-bionic-18.04-amd64-zfs-server-{{ user `buildtime` }}",
+		"ami_description": "Ubuntu Bionic (18.04) with ZFS Root Filesystem",
+		"ami_virtualization_type": "hvm",
+		"ami_root_device": {
+			"source_device_name": "/dev/xvdf",
+			"device_name": "/dev/xvda",
+			"delete_on_termination": true,
+			"volume_size": 8,
+			"volume_type": "gp2"
+		},
+		"tags": {
+			"Name": "Ubuntu Bionic (18.04) with ZFS Root Filesystem",
+			"BuildTime": "{{ user `buildtime` }}"
+		}
+	}],
+	"provisioners": [
+		{
+			"type": "file",
+			"source": "scripts/sources-us-west-2.list",
+			"destination": "/tmp/sources.list"
+		},
+		{
+			"type": "file",
+			"source": "scripts/chroot-bootstrap.sh",
+			"destination": "/tmp/chroot-bootstrap.sh"
+		},
+		{
+			"type": "shell",
+			"start_retry_timeout": "5m",
+			"script": "scripts/surrogate-bootstrap.sh",
+			"skip_clean": true
+		}
+	]
+}
+


### PR DESCRIPTION
This PR adds a builder for Ubuntu 18.04 with ZFS Root ("Bionic Beaver"). Notable changes from 16.04:

- AWS Kernels appear to have ZFS installed by default, so only `zfsutils-linux` is required in the surrogate, and additionally `zfs-initramfs` is required in the chroot.
- We now use `netplan` for interface configuration instead of the older system. "Consistent" interface naming is still disabled, so `eth0` will be the first ethernet interface.
- CloudInit is no longer pinned to an old version