### PR TITLE
Improve bash hygiene in xenial and bionic builders

### DIFF
--- a/bionic/scripts/chroot-bootstrap.sh
+++ b/bionic/scripts/chroot-bootstrap.sh
@@ -21,7 +21,11 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
 
 # Set the locale to en_US.UTF-8
 locale-gen --purge "en_US.UTF-8"
-echo -e 'LANG="en_US.UTF-8"\nLANGUAGE="en_US:en"\n' > /etc/default/locale
+
+cat << EOF > /etc/default/locale
+LANG="en_US.UTF-8
+LANGUAGE="en_US:en"
+EOF
 
 # Install OpenSSH
 apt-get install -y --no-install-recommends openssh-server
@@ -34,12 +38,13 @@ grub-install /dev/xvdf
 
 # Configure and update GRUB
 mkdir -p /etc/default/grub.d
-{
-	echo 'GRUB_RECORDFAIL_TIMEOUT=0'
-	echo 'GRUB_TIMEOUT=0'
-	echo 'GRUB_CMDLINE_LINUX_DEFAULT="console=tty1 console=ttyS0 ip=dhcp tsc=reliable net.ifnames=0"'
-	echo 'GRUB_TERMINAL=console'
-} > /etc/default/grub.d/50-aws-settings.cfg
+cat << EOF > /etc/default/grub.d/50-aws-settings.cfg
+GRUB_RECORDFAIL_TIMEOUT=0
+GRUB_TIMEOUT=0
+GRUB_CMDLINE_LINUX_DEFAULT="console=tty1 console=ttyS0 ip=dhcp tsc=reliable net.ifnames=0"
+GRUB_TERMINAL=console
+EOF
+
 update-grub
 
 # Set options for the default interface

--- a/bionic/template.json
+++ b/bionic/template.json
@@ -51,6 +51,22 @@
 		"ami_name": "ubuntu-bionic-18.04-amd64-zfs-server-{{ user `buildtime` }}",
 		"ami_description": "Ubuntu Bionic (18.04) with ZFS Root Filesystem",
 		"ami_virtualization_type": "hvm",
+		"ami_regions": [
+			"ap-south-1",
+			"ap-northeast-1",
+			"ap-northeast-2",
+			"ap-southeast-1",
+			"ap-southeast-2",
+			"ca-central-1",
+			"eu-west-1",
+			"eu-west-2",
+			"eu-west-3",
+			"eu-central-1",
+			"sa-east-1",
+			"us-east-1",
+			"us-east-2",
+			"us-west-1"
+		],
 		"ami_root_device": {
 			"source_device_name": "/dev/xvdf",
 			"device_name": "/dev/xvda",

--- a/bionic/template.json
+++ b/bionic/template.json
@@ -94,6 +94,7 @@
 			"type": "shell",
 			"start_retry_timeout": "5m",
 			"script": "scripts/surrogate-bootstrap.sh",
+			"execute_command": "sudo -S sh -c '{{ .Vars }} {{ .Path }}'",
 			"skip_clean": true
 		}
 	]

--- a/xenial/scripts/chroot-bootstrap.sh
+++ b/xenial/scripts/chroot-bootstrap.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -ex
+set -o errexit
+set -o pipefail
+set -o xtrace
 
 # Update APT with new sources
 apt-get update
@@ -21,7 +23,11 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
 
 # Set the locale to en_US.UTF-8
 locale-gen --purge "en_US.UTF-8"
-echo -e 'LANG="en_US.UTF-8"\nLANGUAGE="en_US:en"\n' > /etc/default/locale
+
+cat << EOF > /etc/default/locale
+LANG="en_US.UTF-8
+LANGUAGE="en_US:en"
+EOF
 
 # Install OpenSSH
 apt-get install -y --no-install-recommends openssh-server
@@ -34,19 +40,20 @@ grub-install /dev/xvdf
 
 # Configure and update GRUB
 mkdir -p /etc/default/grub.d
-{
-	echo 'GRUB_RECORDFAIL_TIMEOUT=0'
-	echo 'GRUB_TIMEOUT=0'
-	echo 'GRUB_CMDLINE_LINUX_DEFAULT="console=tty1 console=ttyS0 ip=dhcp tsc=reliable net.ifnames=0"'
-	echo 'GRUB_TERMINAL=console'
-} > /etc/default/grub.d/50-aws-settings.cfg
+cat << EOF > /etc/default/grub.d/50-aws-settings.cfg
+GRUB_RECORDFAIL_TIMEOUT=0
+GRUB_TIMEOUT=0
+GRUB_CMDLINE_LINUX_DEFAULT="console=tty1 console=ttyS0 ip=dhcp tsc=reliable net.ifnames=0"
+GRUB_TERMINAL=console
+EOF
+
 update-grub
 
 # Set options for the default interface
-{
-	echo 'auto eth0'
-	echo 'iface eth0 inet dhcp'
-} >> /etc/network/interfaces
+cat << EOF >> /etc/network/interfaces
+auto eth0
+iface eth0 inet dhcp
+EOF
 
 # Install standard packages
 DEBIAN_FRONTEND=noninteractive apt-get install -y ubuntu-standard

--- a/xenial/scripts/surrogate-bootstrap.sh
+++ b/xenial/scripts/surrogate-bootstrap.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -ex
+set -o errexit
+set -o pipefail
+set -o xtrace
 
 # Update apt and install required packages
 DEBIAN_FRONTEND=noninteractive sudo apt-get update

--- a/xenial/scripts/surrogate-bootstrap.sh
+++ b/xenial/scripts/surrogate-bootstrap.sh
@@ -4,9 +4,11 @@ set -o errexit
 set -o pipefail
 set -o xtrace
 
+export DEBIAN_FRONTEND=noninteractive
+
 # Update apt and install required packages
-DEBIAN_FRONTEND=noninteractive sudo apt-get update
-DEBIAN_FRONTEND=noninteractive sudo apt-get install -y \
+apt-get update
+apt-get install -y \
 	zfs-zed \
 	zfsutils-linux \
 	zfs-initramfs \
@@ -15,10 +17,10 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get install -y \
 	gdisk
 
 # Partition the new root EBS volume
-sudo sgdisk -Zg -n1:0:4095 -t1:EF02 -c1:GRUB -n2:0:0 -t2:BF01 -c2:ZFS /dev/xvdf
+sgdisk -Zg -n1:0:4095 -t1:EF02 -c1:GRUB -n2:0:0 -t2:BF01 -c2:ZFS /dev/xvdf
 
 # Create zpool and filesystems on the new EBS volume
-sudo zpool create \
+zpool create \
 	-o altroot=/mnt \
 	-o ashift=12 \
 	-o cachefile=/etc/zfs/zpool.cache \
@@ -31,92 +33,92 @@ sudo zpool create \
 	/dev/xvdf2
 
 # Root file system
-sudo zfs create \
+zfs create \
 	-o canmount=off \
 	-o mountpoint=none \
 	rpool/ROOT
 
-sudo zfs create \
+zfs create \
 	-o canmount=noauto \
 	-o mountpoint=/ \
 	rpool/ROOT/ubuntu
 
-sudo zfs mount rpool/ROOT/ubuntu
+zfs mount rpool/ROOT/ubuntu
 
 # /home
-sudo zfs create \
+zfs create \
 	-o setuid=off \
 	-o mountpoint=/home \
 	rpool/home
 
-sudo zfs create \
+zfs create \
 	-o mountpoint=/root \
 	rpool/home/root
 
 # /var
-sudo zfs create \
+zfs create \
 	-o setuid=off \
 	-o overlay=on \
 	-o mountpoint=/var \
 	rpool/var
 
-sudo zfs create \
+zfs create \
 	-o com.sun:auto-snapshot=false \
 	-o mountpoint=/var/cache \
 	rpool/var/cache
 
-sudo zfs create \
+zfs create \
 	-o com.sun:auto-snapshot=false \
 	-o mountpoint=/var/tmp \
 	rpool/var/tmp
 
-sudo zfs create \
+zfs create \
 	-o mountpoint=/var/spool \
 	rpool/var/spool
 
-sudo zfs create \
+zfs create \
 	-o exec=on \
 	-o mountpoint=/var/lib \
 	rpool/var/lib
 
-sudo zfs create \
+zfs create \
 	-o mountpoint=/var/log \
 	rpool/var/log
 
 # Display ZFS output for debugging purposes
-sudo zpool status
-sudo zfs list
+zpool status
+zfs list
 
 # Bootstrap Ubuntu Yakkety into /mnt
-sudo debootstrap --arch amd64 xenial /mnt
-sudo cp /tmp/sources.list /mnt/etc/apt/sources.list
+debootstrap --arch amd64 xenial /mnt
+cp /tmp/sources.list /mnt/etc/apt/sources.list
 
 # Copy the zpool cache
-sudo mkdir -p /mnt/etc/zfs
-sudo cp -p /etc/zfs/zpool.cache /mnt/etc/zfs/zpool.cache
+mkdir -p /mnt/etc/zfs
+cp -p /etc/zfs/zpool.cache /mnt/etc/zfs/zpool.cache
 
 # Create mount points and mount the filesystem
-sudo mkdir -p /mnt/{dev,proc,sys}
-sudo mount --rbind /dev /mnt/dev
-sudo mount --rbind /proc /mnt/proc
-sudo mount --rbind /sys /mnt/sys
+mkdir -p /mnt/{dev,proc,sys}
+mount --rbind /dev /mnt/dev
+mount --rbind /proc /mnt/proc
+mount --rbind /sys /mnt/sys
 
 # Copy the bootstrap script into place and execute inside chroot
-sudo cp /tmp/chroot-bootstrap.sh /mnt/tmp/chroot-bootstrap.sh
-sudo chroot /mnt /tmp/chroot-bootstrap.sh
-sudo rm -f /mnt/tmp/chroot-bootstrap.sh
+cp /tmp/chroot-bootstrap.sh /mnt/tmp/chroot-bootstrap.sh
+chroot /mnt /tmp/chroot-bootstrap.sh
+rm -f /mnt/tmp/chroot-bootstrap.sh
 
 # Remove temporary sources list - CloudInit regenerates it
-sudo rm -f /mnt/etc/apt/sources.list
+rm -f /mnt/etc/apt/sources.list
 
 # This could perhaps be replaced (more reliably) with an `lsof | grep -v /mnt` loop,
 # however in approximately 20 runs, the bind mounts have not failed to unmount.
 sleep 10 
 
 # Unmount bind mounts
-sudo umount -l /mnt/dev
-sudo umount -l /mnt/proc
-sudo umount -l /mnt/sys
+umount -l /mnt/dev
+umount -l /mnt/proc
+umount -l /mnt/sys
 
 # Export the zpool
-sudo zpool export rpool
+zpool export rpool

--- a/xenial/template.json
+++ b/xenial/template.json
@@ -60,6 +60,7 @@
 			"ca-central-1",
 			"eu-west-1",
 			"eu-west-2",
+			"eu-west-3",
 			"eu-central-1",
 			"sa-east-1",
 			"us-east-1",

--- a/xenial/template.json
+++ b/xenial/template.json
@@ -94,6 +94,7 @@
 			"type": "shell",
 			"start_retry_timeout": "5m",
 			"script": "scripts/surrogate-bootstrap.sh",
+			"execute_command": "sudo -S sh -c '{{ .Vars }} {{ .Path }}'",
 			"skip_clean": true
 		}
 	]

--- a/xenial/template.json
+++ b/xenial/template.json
@@ -51,7 +51,6 @@
 		"ami_name": "ubuntu-xenial-16.04-amd64-zfs-server-{{ user `buildtime` }}",
 		"ami_description": "Ubuntu Xenial (16.04) with ZFS Root Filesystem",
 		"ami_virtualization_type": "hvm",
-		"ena_support": true,
 		"ami_regions": [
 			"ap-south-1",
 			"ap-northeast-1",


### PR DESCRIPTION
This PR has a few updates:

- Removes the use of `sudo` by running the surrogate bootstrap command as root via Packer's `execute_command`
- Remove `ena_support` from the `xenial` template to make it work with more recent versions of Packer
- Adds `eu-west-3` to the `xenial` `ami_regions` list,  and adds the list to the `bionic` builder.