### PR TITLE
Add builder in HCL for Ubuntu 20.04

### DIFF
--- a/focal/files/70-ec2-nvme-devices.rules
+++ b/focal/files/70-ec2-nvme-devices.rules
@@ -1,0 +1,25 @@
+# Copyright (C) 2006-2016 Amazon.com, Inc. or its affiliates.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#    http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+
+#nvme-ns-* devices
+KERNEL=="nvme[0-9]*n[0-9]*", ENV{DEVTYPE}=="disk", ATTRS{serial}=="?*", ATTRS{model}=="?*", SYMLINK+="disk/by-id/nvme-$attr{model}_$attr{serial}-ns-%n", OPTIONS+="string_escape=replace"
+
+#nvme partitions
+KERNEL=="nvme[0-9]*n[0-9]*p[0-9]*", ENV{DEVTYPE}=="partition", ATTRS{serial}=="?*", ATTRS{model}=="?*",  IMPORT{program}="ec2nvme-nsid %k"
+KERNEL=="nvme[0-9]*n[0-9]*p[0-9]*", ENV{DEVTYPE}=="partition", ATTRS{serial}=="?*", ATTRS{model}=="?*",  ENV{_NS_ID}=="?*", SYMLINK+="disk/by-id/nvme-$attr{model}_$attr{serial}-ns-$env{_NS_ID}-part%n", OPTIONS+="string_escape=replace"
+
+# ebs nvme devices
+KERNEL=="nvme[0-9]*n[0-9]*",        ENV{DEVTYPE}=="disk",      ATTRS{model}=="Amazon Elastic Block Store", PROGRAM="/sbin/ebsnvme-id -u /dev/%k", SYMLINK+="%c"
+KERNEL=="nvme[0-9]*n[0-9]*p[0-9]*", ENV{DEVTYPE}=="partition", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM="/sbin/ebsnvme-id -u /dev/%k", SYMLINK+="%c%n"

--- a/focal/files/ebsnvme-id
+++ b/focal/files/ebsnvme-id
@@ -1,0 +1,173 @@
+#!/usr/bin/env python2.7
+
+# Copyright (C) 2017 Amazon.com, Inc. or its affiliates.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#    http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+
+"""
+Usage:
+Read EBS device information and provide information about
+the volume.
+"""
+
+import argparse
+from ctypes import *
+from fcntl import ioctl
+import sys
+
+NVME_ADMIN_IDENTIFY = 0x06
+NVME_IOCTL_ADMIN_CMD = 0xC0484E41
+AMZN_NVME_VID = 0x1D0F
+AMZN_NVME_EBS_MN = "Amazon Elastic Block Store"
+
+class nvme_admin_command(Structure):
+    _pack_ = 1
+    _fields_ = [("opcode", c_uint8),      # op code
+                ("flags", c_uint8),       # fused operation
+                ("cid", c_uint16),        # command id
+                ("nsid", c_uint32),       # namespace id
+                ("reserved0", c_uint64),
+                ("mptr", c_uint64),       # metadata pointer
+                ("addr", c_uint64),       # data pointer
+                ("mlen", c_uint32),       # metadata length
+                ("alen", c_uint32),       # data length
+                ("cdw10", c_uint32),
+                ("cdw11", c_uint32),
+                ("cdw12", c_uint32),
+                ("cdw13", c_uint32),
+                ("cdw14", c_uint32),
+                ("cdw15", c_uint32),
+                ("reserved1", c_uint64)]
+
+class nvme_identify_controller_amzn_vs(Structure):
+    _pack_ = 1
+    _fields_ = [("bdev", c_char * 32),  # block device name
+                ("reserved0", c_char * (1024 - 32))]
+
+class nvme_identify_controller_psd(Structure):
+    _pack_ = 1
+    _fields_ = [("mp", c_uint16),       # maximum power
+                ("reserved0", c_uint16),
+                ("enlat", c_uint32),     # entry latency
+                ("exlat", c_uint32),     # exit latency
+                ("rrt", c_uint8),       # relative read throughput
+                ("rrl", c_uint8),       # relative read latency
+                ("rwt", c_uint8),       # relative write throughput
+                ("rwl", c_uint8),       # relative write latency
+                ("reserved1", c_char * 16)]
+
+class nvme_identify_controller(Structure):
+    _pack_ = 1
+    _fields_ = [("vid", c_uint16),          # PCI Vendor ID
+                ("ssvid", c_uint16),        # PCI Subsystem Vendor ID
+                ("sn", c_char * 20),        # Serial Number
+                ("mn", c_char * 40),        # Module Number
+                ("fr", c_char * 8),         # Firmware Revision
+                ("rab", c_uint8),           # Recommend Arbitration Burst
+                ("ieee", c_uint8 * 3),      # IEEE OUI Identifier
+                ("mic", c_uint8),           # Multi-Interface Capabilities
+                ("mdts", c_uint8),          # Maximum Data Transfer Size
+                ("reserved0", c_uint8 * (256 - 78)),
+                ("oacs", c_uint16),         # Optional Admin Command Support
+                ("acl", c_uint8),           # Abort Command Limit
+                ("aerl", c_uint8),          # Asynchronous Event Request Limit
+                ("frmw", c_uint8),          # Firmware Updates
+                ("lpa", c_uint8),           # Log Page Attributes
+                ("elpe", c_uint8),          # Error Log Page Entries
+                ("npss", c_uint8),          # Number of Power States Support
+                ("avscc", c_uint8),         # Admin Vendor Specific Command Configuration
+                ("reserved1", c_uint8 * (512 - 265)),
+                ("sqes", c_uint8),          # Submission Queue Entry Size
+                ("cqes", c_uint8),          # Completion Queue Entry Size
+                ("reserved2", c_uint16),
+                ("nn", c_uint32),            # Number of Namespaces
+                ("oncs", c_uint16),         # Optional NVM Command Support
+                ("fuses", c_uint16),        # Fused Operation Support
+                ("fna", c_uint8),           # Format NVM Attributes
+                ("vwc", c_uint8),           # Volatile Write Cache
+                ("awun", c_uint16),         # Atomic Write Unit Normal
+                ("awupf", c_uint16),        # Atomic Write Unit Power Fail
+                ("nvscc", c_uint8),         # NVM Vendor Specific Command Configuration
+                ("reserved3", c_uint8 * (704 - 531)),
+                ("reserved4", c_uint8 * (2048 - 704)),
+                ("psd", nvme_identify_controller_psd * 32),     # Power State Descriptor
+                ("vs", nvme_identify_controller_amzn_vs)]  # Vendor Specific
+
+class ebs_nvme_device:
+    def __init__(self, device):
+        self.device = device
+        self.ctrl_identify()
+
+    def _nvme_ioctl(self, id_response, id_len):
+        admin_cmd = nvme_admin_command(opcode = NVME_ADMIN_IDENTIFY,
+                                       addr = id_response,
+                                       alen = id_len,
+                                       cdw10 = 1)
+
+        with open(self.device, "rw") as nvme:
+            ioctl(nvme, NVME_IOCTL_ADMIN_CMD, admin_cmd)
+
+    def ctrl_identify(self):
+        self.id_ctrl = nvme_identify_controller()
+        self._nvme_ioctl(addressof(self.id_ctrl), sizeof(self.id_ctrl))
+
+        if self.id_ctrl.vid != AMZN_NVME_VID or self.id_ctrl.mn.strip() != AMZN_NVME_EBS_MN:
+            raise TypeError("[ERROR] Not an EBS device: '{0}'".format(self.device))
+
+    def get_volume_id(self):
+        vol = self.id_ctrl.sn
+
+        if vol.startswith("vol") and vol[3] != "-":
+            vol = "vol-" + vol[3:]
+
+        return vol
+
+    def get_block_device(self, stripped=False):
+        dev = self.id_ctrl.vs.bdev.strip()
+
+        if stripped and dev.startswith("/dev/"):
+            dev = dev[5:]
+
+        return dev
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Reads EBS information from NVMe devices.")
+    parser.add_argument("device", nargs=1, help="Device to query")
+
+    display = parser.add_argument_group("Display Options")
+    display.add_argument("-v", "--volume", action="store_true",
+            help="Return volume-id")
+    display.add_argument("-b", "--block-dev", action="store_true",
+            help="Return block device mapping")
+    display.add_argument("-u", "--udev", action="store_true",
+            help="Output data in format suitable for udev rules")
+
+    if len(sys.argv) < 2:
+        parser.print_help()
+        sys.exit(1)
+
+    args = parser.parse_args()
+
+    get_all = not (args.udev or args.volume or args.block_dev)
+
+    try:
+        dev = ebs_nvme_device(args.device[0])
+    except (IOError, TypeError) as err:
+        print >> sys.stderr, err
+        sys.exit(1)
+
+    if get_all or args.volume:
+        print "Volume ID: {0}".format(dev.get_volume_id())
+    if get_all or args.block_dev or args.udev:
+        print dev.get_block_device(args.udev)

--- a/focal/files/sources-us-west-2.list
+++ b/focal/files/sources-us-west-2.list
@@ -1,0 +1,6 @@
+deb http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ focal main restricted
+deb-src http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ focal main restricted
+
+deb http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ focal-updates main restricted
+deb-src http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ focal-updates main restricted
+

--- a/focal/scripts/chroot-bootstrap.sh
+++ b/focal/scripts/chroot-bootstrap.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+# Update APT with new sources
+sleep 10
+cat /etc/apt/sources.list
+apt-get update
+
+# Do not configure grub during package install
+echo 'grub-pc grub-pc/install_devices_empty select true' | debconf-set-selections
+echo 'grub-pc grub-pc/install_devices select' | debconf-set-selections
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Install various packages needed for a booting system
+apt-get install -y \
+	linux-aws \
+	grub-pc \
+	zfsutils-linux \
+	zfs-initramfs \
+	gdisk
+
+cat << EOF > /etc/default/locale
+LANG="C.UTF-8"
+LC_CTYPE="C.UTF-8"
+EOF
+
+# Install OpenSSH
+apt-get install -y --no-install-recommends openssh-server
+
+# Install GRUB
+# shellcheck disable=SC2016
+sed -ri 's/GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX="boot=zfs \$bootfs"/' /etc/default/grub
+grub-probe /
+grub-install /dev/xvdf
+
+# Configure and update GRUB
+mkdir -p /etc/default/grub.d
+cat << EOF > /etc/default/grub.d/50-aws-settings.cfg
+GRUB_RECORDFAIL_TIMEOUT=0
+GRUB_TIMEOUT=0
+GRUB_CMDLINE_LINUX_DEFAULT="console=tty1 console=ttyS0 ip=dhcp tsc=reliable net.ifnames=0"
+GRUB_TERMINAL=console
+EOF
+
+update-grub
+
+# Set options for the default interface
+cat << EOF > /etc/netplan/eth0.yaml
+network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp4: true
+EOF
+
+# Install standard packages
+apt-get install -y ubuntu-standard \
+	cloud-init

--- a/focal/scripts/surrogate-bootstrap.sh
+++ b/focal/scripts/surrogate-bootstrap.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Wait for cloudinit on the surrogate to complete before making progress
+while [[ ! -f /var/lib/cloud/instance/boot-finished ]]; do
+    echo 'Waiting for cloud-init...'
+    sleep 1
+done
+
+# Update apt and install required packages
+apt-get update
+apt-get install -y \
+	gdisk \
+	zfsutils-linux \
+	debootstrap
+
+# Partition the new root EBS volume
+sgdisk -Zg -n1:0:4095 -t1:EF02 -c1:GRUB -n2:0:0 -t2:BF01 -c2:ZFS /dev/xvdf
+
+# Create zpool and filesystems on the new EBS volume
+zpool create \
+	-o altroot=/mnt \
+	-o ashift=12 \
+	-o cachefile=/etc/zfs/zpool.cache \
+	-O canmount=off \
+	-O compression=lz4 \
+	-O atime=off \
+	-O normalization=formD \
+	-m none \
+	rpool \
+	/dev/xvdf2
+
+# Root file system
+zfs create \
+	-o canmount=off \
+	-o mountpoint=none \
+	rpool/ROOT
+
+zfs create \
+	-o canmount=noauto \
+	-o mountpoint=/ \
+	rpool/ROOT/ubuntu
+
+zfs mount rpool/ROOT/ubuntu
+
+# /home
+zfs create \
+	-o setuid=off \
+	-o mountpoint=/home \
+	rpool/home
+
+zfs create \
+	-o mountpoint=/root \
+	rpool/home/root
+
+# /var
+zfs create \
+	-o setuid=off \
+	-o overlay=on \
+	-o mountpoint=/var \
+	rpool/var
+
+zfs create \
+	-o com.sun:auto-snapshot=false \
+	-o mountpoint=/var/cache \
+	rpool/var/cache
+
+zfs create \
+	-o com.sun:auto-snapshot=false \
+	-o mountpoint=/var/tmp \
+	rpool/var/tmp
+
+zfs create \
+	-o mountpoint=/var/spool \
+	rpool/var/spool
+
+zfs create \
+	-o exec=on \
+	-o mountpoint=/var/lib \
+	rpool/var/lib
+
+zfs create \
+	-o mountpoint=/var/log \
+	rpool/var/log
+
+# Display ZFS output for debugging purposes
+zpool status
+zfs list
+
+# Bootstrap Ubuntu into /mnt
+debootstrap --arch amd64 focal /mnt
+cp /tmp/sources.list /mnt/etc/apt/sources.list
+
+# Copy the zpool cache
+mkdir -p /mnt/etc/zfs
+cp -p /etc/zfs/zpool.cache /mnt/etc/zfs/zpool.cache
+
+# Create mount points and mount the filesystem
+mkdir -p /mnt/{dev,proc,sys}
+mount --rbind /dev /mnt/dev
+mount --rbind /proc /mnt/proc
+mount --rbind /sys /mnt/sys
+
+# Copy the bootstrap script into place and execute inside chroot
+cp /tmp/chroot-bootstrap.sh /mnt/tmp/chroot-bootstrap.sh
+chroot /mnt /tmp/chroot-bootstrap.sh
+rm -f /mnt/tmp/chroot-bootstrap.sh
+
+# Copy the nvme identification script into /sbin inside the chroot
+mkdir -p /mnt/sbin
+cp /tmp/ebsnvme-id /mnt/sbin/ebsnvme-id
+chmod +x /mnt/sbin/ebsnvme-id
+
+# Copy the udev rules for identifying nvme devices into the chroot
+mkdir -p /mnt/etc/udev/rules.d
+cp /tmp/70-ec2-nvme-devices.rules \
+	/mnt/etc/udev/rules.d/70-ec2-nvme-devices.rules
+
+# Remove temporary sources list - CloudInit regenerates it
+rm -f /mnt/etc/apt/sources.list
+
+# This could perhaps be replaced (more reliably) with an `lsof | grep -v /mnt` loop,
+# however in approximately 20 runs, the bind mounts have not failed to unmount.
+sleep 10 
+
+# Unmount bind mounts
+umount -l /mnt/dev
+umount -l /mnt/proc
+umount -l /mnt/sys
+
+# Export the zpool
+zpool export rpool

--- a/focal/template.pkr.hcl
+++ b/focal/template.pkr.hcl
@@ -1,0 +1,87 @@
+source "amazon-ebssurrogate" "source" {
+	source_ami_filter {
+		filters {
+			virtualization-type = "hvm"
+			name = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"
+			root-device-type = "ebs"
+		}
+		owners = [
+			"099720109477" // Canonical
+		]
+		most_recent = true
+	}
+
+	instance_type = "m4.large"
+	region = "us-west-2"
+	ena_support = true
+
+	launch_block_device_mappings {
+		device_name = "/dev/xvdf"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+
+	run_tags {
+		Name = "Packer Builder - ZFS Root Ubuntu"
+	}
+	run_volume_tags {
+		Name = "Packer Builder - ZFS Root Ubuntu"
+	}
+
+	communicator = "ssh"
+	ssh_pty = true
+	ssh_username = "ubuntu"
+	ssh_timeout = "5m"
+
+	ami_name = "ubuntu-focal-20.04-amd64-zfs-server"
+	ami_description = "Ubuntu Focal (20.04) with ZFS Root Filesystem"
+	ami_virtualization_type = "hvm"
+	ami_regions = []
+	ami_root_device {
+		source_device_name = "/dev/xvdf"
+		device_name = "/dev/xvda"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+
+	tags {
+		Name = "Ubuntu Focal (20.04) with ZFS Root Filesystem"
+		BuildTime = timestamp()
+	}
+}
+
+build {
+	sources = [
+		"source.amazon-ebssurrogate.source"
+	]
+
+	provisioner "file" {
+		source = "files/sources-us-west-2.list"
+		destination = "/tmp/sources.list"
+	}
+
+	provisioner "file" {
+		source = "files/ebsnvme-id"
+		destination = "/tmp/ebsnvme-id"
+	}
+
+	provisioner "file" {
+		source = "files/70-ec2-nvme-devices.rules"
+		destination = "/tmp/70-ec2-nvme-devices.rules"
+	}
+
+	provisioner "file" {
+		source = "scripts/chroot-bootstrap.sh"
+		destination = "/tmp/chroot-bootstrap.sh"
+	}
+
+	provisioner "shell" {
+		script = "scripts/surrogate-bootstrap.sh"
+		execute_command = "sudo -S sh -c '{{ .Vars }} {{ .Path }}'"
+
+		start_retry_timeout = "5m"
+		skip_clean = true
+	}
+}


### PR DESCRIPTION
This commit adds a pull request to add support for Ubuntu 20.04 on Root ZFS, using an HCL form of the Packer template. This is tested with the current version of Packer, which is v1.5.5.