### PR TITLE
Wait for cloudinit to complete on surrogate boot

### DIFF
--- a/bionic/scripts/surrogate-bootstrap.sh
+++ b/bionic/scripts/surrogate-bootstrap.sh
@@ -6,6 +6,12 @@ set -o xtrace
 
 export DEBIAN_FRONTEND=noninteractive
 
+# Wait for cloudinit on the surrogate to complete before making progress
+while [[ ! -f /var/lib/cloud/instance/boot-finished ]]; do
+    echo 'Waiting for cloud-init...'
+    sleep 1
+done
+
 # Update apt and install required packages
 apt-get update
 apt-get install -y \

--- a/xenial/scripts/surrogate-bootstrap.sh
+++ b/xenial/scripts/surrogate-bootstrap.sh
@@ -6,6 +6,12 @@ set -o xtrace
 
 export DEBIAN_FRONTEND=noninteractive
 
+# Wait for cloudinit on the surrogate to complete before making progress
+while [[ ! -f /var/lib/cloud/instance/boot-finished ]]; do
+    echo 'Waiting for cloud-init...'
+    sleep 1
+done
+
 # Update apt and install required packages
 apt-get update
 apt-get install -y \


### PR DESCRIPTION
This fixes an issue reported in #5 whereby packages sometimes failed to install on the surrogate. This is already fixed in the focal builder, and this commit back ports the fix to xenial and bionic.