### PR TITLE
Explicitly configure cloudinit/growpart for ZFS

### DIFF
--- a/focal/files/zfs-growpart-root.cfg
+++ b/focal/files/zfs-growpart-root.cfg
@@ -1,0 +1,2 @@
+growpart:
+   devices: ['/dev/disk/by-label/rpool']

--- a/focal/scripts/surrogate-bootstrap.sh
+++ b/focal/scripts/surrogate-bootstrap.sh
@@ -121,6 +121,11 @@ mkdir -p /mnt/etc/udev/rules.d
 cp /tmp/70-ec2-nvme-devices.rules \
 	/mnt/etc/udev/rules.d/70-ec2-nvme-devices.rules
 
+# Copy the ZFS-compatible growpart configuration for cloud-init into the chroot
+mkdir -p /mnt/etc/cloud/cloud.cfg.d
+cp /tmp/zfs-growpart-root.cfg \
+    /mnt/etc/cloud/cloud.cfg.d/zfs-growpart-root.cfg
+
 # Remove temporary sources list - CloudInit regenerates it
 rm -f /mnt/etc/apt/sources.list
 

--- a/focal/template.pkr.hcl
+++ b/focal/template.pkr.hcl
@@ -73,6 +73,11 @@ build {
 	}
 
 	provisioner "file" {
+		source = "files/zfs-growpart-root.cfg"
+		destination = "/tmp/zfs-growpart-root.cfg"
+	}
+
+	provisioner "file" {
 		source = "scripts/chroot-bootstrap.sh"
 		destination = "/tmp/chroot-bootstrap.sh"
 	}


### PR DESCRIPTION
As reported in #13, the root partition does not automatically grow if an instance is launched from the AMI produced by the `focal` template with a larger root volume than 8GB (the size of the volume snapshot).

This was eventually tracked down to Cloud-Init failing to resolve the correct partition to expand, though the step to grow the filesystem does support ZFS correctly. Instead of relying on Cloud-Init to detect the device identifier partition by parsing `/proc/<PID>/mountinfo`, we can explicitly set the partition to `/dev/disk/by-label/rpool`, which points to the correct partition.

This commit adds configuration to `/etc/cloud/cloud.cfg.d` to do so.

When booting an image built with this commit on a 16GB root volume, `zpool list` after first boot reports the following:

```
ubuntu@ip-172-31-14-190:~$ zpool list
NAME    SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
rpool  15.5G   668M  14.8G        -         -     0%     4%  1.00x    ONLINE  -
```

Fixes #13.