### PR TITLE
Focal - same packages as standard ubuntu AMIs

### DIFF
--- a/focal/scripts/chroot-bootstrap.sh
+++ b/focal/scripts/chroot-bootstrap.sh
@@ -59,7 +59,16 @@ EOF
 
 # Install standard packages
 apt-get install -y ubuntu-standard \
-	cloud-init
+	cloud-init \
+	ubuntu-server \
+	acpid \
+	ec2-hibinit-agent \
+	ec2-instance-connect \
+	hibagent \
+	krb5-locales \
+	ncurses-term \
+	ssh-import-id \
+	xauth
 
 # Clear apt caches
 apt-get clean


### PR DESCRIPTION
Implements: #21 

Confirmed that the resulting image build completes:
```
packer-ubuntu-zfs fred$ AWS_PROFILE=admin-main make focal
amazon-ebssurrogate.source: output will be in this color.

==> amazon-ebssurrogate.source: Prevalidating any provided VPC information
==> amazon-ebssurrogate.source: Prevalidating AMI Name: ubuntu-focal-20.04-amd64-zfs-server-2020-10-25-2145
    amazon-ebssurrogate.source: Found Image ID: ami-032ed93ef3b2a867c
...
Build 'amazon-ebssurrogate.source' finished after 15 minutes 43 seconds.

==> Wait completed after 15 minutes 43 seconds

==> Builds finished. The artifacts of successful builds are:
--> amazon-ebssurrogate.source: AMIs were created:
us-west-2: ami-0cd1b262022db24e2
```
* https://github.com/fred-vogt/packer-ubuntu-zfs/wiki